### PR TITLE
add remote control interface

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = tab
+indent_size = 4

--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,18 @@
+<?php
+
+// Pusher requires using "Private Channels" in order to allow clients to send commands.
+// This requires a tiny bit of code that can sign requests for "authenticated" users.
+// We're treating every client as an authenticated user and signing everything blindly.
+// This effectively makes them public channels again.
+// https://pusher.com/docs/channels/using_channels/private-channels
+
+ob_start();
+require(__DIR__.'/js/pusher.php');
+ob_end_clean();
+
+$auth = hash_hmac('sha256', $_POST['socket_id'].':'.$_POST['channel_name'], $secret);
+
+header('Content-type: application/json');
+echo json_encode([
+	'auth' => $key.':'.$auth
+]);

--- a/css/style.css
+++ b/css/style.css
@@ -233,3 +233,60 @@ article .teleprompter.flipxy
 	outline: none;
 	margin: 4px 0;
 }
+.hidden
+{
+	display: none !important;
+}
+
+
+#control
+{
+	background: #333;
+	top: 0;
+	bottom: 0;
+	width: 100vw;
+	height: 100vh;
+	z-index: 20;
+	position: absolute;
+}
+#control header
+{
+	text-align: right;
+	padding-right: 20px;
+	position: relative;
+}
+#control section
+{
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+#control section .button
+{
+	font-size: 80px;
+	height: 90px;
+	width: 80px;
+	line-height: 100px !important;
+	margin: 10px 0;
+}
+#control .plusminus-controls
+{
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	width: 100%;
+	max-width: 300px;
+}
+#control .plusminus-controls a
+{
+	flex: 0;
+}
+#control .plusminus-controls span
+{
+	flex: 1;
+	text-align: center;
+}
+#control .font-size-control
+{
+	margin-top: 40px;
+}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 		<meta name="keywords" content="TelePrompter, HTML, HTML5, CSS, CSS3, Javascript">
 
 		<!-- Mobile Specific Meta Tags -->
-		<meta name="viewport" content="width=1024, initial-scale=1, maximum-scale=1">
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-status-bar-style" content="black">
 
@@ -19,12 +19,15 @@
 		<link rel="stylesheet" href="https://code.jquery.com/ui/1.10.3/themes/redmond/jquery-ui.css" />
 		<link rel="stylesheet" href="css/style.css?v=0.6.1">
 		<link rel="stylesheet" href="css/font-awesome.min.css">
+		<script src="https://js.pusher.com/4.4/pusher.min.js"></script>
 	</head>
 	<body id="gui">
 		<header>
 			<h1><i class="icon icon-bullhorn"></i> <span class="clock">00:00:00</span></h1>
 			<nav>
-                <div class="buttons">
+        <div class="buttons">
+					<a class="button small icon-th control hidden" href="#" onclick="return false;"></a>
+					<a class="button small icon-link link hidden" href="#" onclick="return false;"></a>
 					<a class="button small icon-undo reset" href="#" onclick="return false;"></a>
 					<a class="button small icon-text-width flipx" href="#" onclick="return false;"></a>
 					<a class="button small icon-text-height flipy" href="#" onclick="return false;"></a>
@@ -74,6 +77,29 @@
 			</div>
 			<i class="icon-play marker"></i>
 		</article>
+		<article id="control" class="hidden">
+			<header>
+				<a class="button icon-remove close-controls" href="#" onclick="return false;"></a>
+			</header>
+			<section>
+				<a class="button icon-chevron-up scroll-up" href="#" onclick="return false;"></a>
+				<a class="button icon-play control-play" href="#" onclick="return false;"></a>
+				<a class="button icon-chevron-down scroll-down" href="#" onclick="return false;"></a>
+
+				<div class="font-size-control plusminus-controls">
+					<a class="button icon-minus decrease" href="#" onclick="return false;"></a>
+					<span>Font Size</span>
+					<a class="button icon-plus increase" href="#" onclick="return false;"></a>
+				</div>
+
+				<div class="speed-control plusminus-controls">
+					<a class="button icon-minus decrease" href="#" onclick="return false;"></a>
+					<span>Speed</span>
+					<a class="button icon-plus increase" href="#" onclick="return false;"></a>
+				</div>
+
+			</section>
+		</article>
 		<footer>
 
 		</footer>
@@ -81,7 +107,9 @@
 		<script src="https://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
 		<script src="js/jquery.timer.js"></script>
 		<script src="js/jquery.cookie.js"></script>
-        <script src="js/jscolor.js"></script>
-		<script src="js/script.js?v=0.6.2"></script>
+		<script src="js/jscolor.js"></script>
+		<script src="js/script.js?v=0.6.3"></script>
+		<script src="js/pusher.php?v=0.1.0"></script>
+		<script src="js/stream.js?v=0.1.0"></script>
 	</body>
 </html>

--- a/js/pusher.php
+++ b/js/pusher.php
@@ -1,0 +1,17 @@
+/*
+<?php
+
+// Enter your Pusher.com Key and Secret here
+$key    = '';
+$secret = '';
+
+//////////////////////////////////////////////////////////////////
+// The tricky comments here will make sure there are no JS errors
+// if this file is output as JS without interpreting PHP.
+
+// When loaded via JS, we want to set the Pusher.apiKey variable
+header('Content-type: text/javascript');
+echo "*"."/\n";
+echo "Pusher.apiKey = '$key';\n";
+
+// */

--- a/js/script.js
+++ b/js/script.js
@@ -58,8 +58,8 @@ $(function() {
 		orientation: "horizontal",
 		range: "min",
 		animate: true,
-		slide: function(){ fontSize(true); },
-		change: function(){ fontSize(true); }
+		slide: function(){ fontSize(true, false); },
+		change: function(){ fontSize(true, true); }
 	});
 
 	// Create Speed Slider
@@ -70,10 +70,10 @@ $(function() {
 		orientation: "horizontal",
 		range: "min",
 		animate: true,
-		slide: function(){ speed(true); },
-		change: function(){ speed(true); }
+		slide: function(){ speed(true, false); },
+		change: function(){ speed(true, true); }
 	});
-	
+
 	$('#text-color').change(function(){
 		var color = $(this).val();
 		$('#teleprompter').css('color', color);
@@ -143,7 +143,7 @@ $(function() {
 });
 
 // Manage Font Size Change
-function fontSize(save_cookie)
+function fontSize(save_cookie, send_control_command)
 {
 	initFontSize = $('.font_size').slider( "value" );
 
@@ -160,6 +160,12 @@ function fontSize(save_cookie)
 
 	$('label.font_size_label span').text('(' + initFontSize + ')');
 
+	// Avoid sending the control command when the slider is scrolled, in order to avoid rate limits
+	if(send_control_command)
+	{
+		controlFontSize();
+	}
+
 	if(save_cookie)
 	{
 		$.cookie('teleprompter_font_size', initFontSize);
@@ -167,10 +173,16 @@ function fontSize(save_cookie)
 }
 
 // Manage Speed Change
-function speed(save_cookie)
+function speed(save_cookie, send_control_command)
 {
 	initPageSpeed = Math.floor(50 - $('.speed').slider('value'));
 	$('label.speed_label span').text('(' + $('.speed').slider('value') + ')');
+
+	// Avoid sending the control command when the slider is scrolled, in order to avoid rate limits
+	if(send_control_command)
+	{
+		controlSpeed();
+	}
 
 	if(save_cookie)
 	{
@@ -209,6 +221,22 @@ function pageScroll()
         $('article').stop().animate({scrollTop: 0}, 500, 'swing', function(){ $('article').clearQueue(); });
       }, 500);
     }
+	}
+}
+
+function scrollUp() {
+	if ($('.teleprompter').hasClass('flipy')) {
+		$('article').animate({scrollTop: "+=40px" }, 0, 'linear', function(){ $('article').clearQueue(); });
+	} else {
+		$('article').animate({scrollTop: "-=40px" }, 0, 'linear', function(){ $('article').clearQueue(); });
+	}
+}
+
+function scrollDown() {
+	if ($('.teleprompter').hasClass('flipy')) {
+		$('article').animate({scrollTop: "-=40px" }, 0, 'linear', function(){ $('article').clearQueue(); });
+	} else {
+		$('article').animate({scrollTop: "+=40px" }, 0, 'linear', function(){ $('article').clearQueue(); });
 	}
 }
 

--- a/js/stream.js
+++ b/js/stream.js
@@ -1,0 +1,192 @@
+
+if(Pusher.apiKey) {
+
+	Pusher.logToConsole = true;
+
+	var pusher = new Pusher(Pusher.apiKey, {
+		cluster: 'us3',
+		forceTLS: true,
+		authEndpoint: '/auth.php'
+	});
+	var channel;
+
+	$(function(){
+
+		$('.button.link').removeClass('hidden');
+
+		$('.button.link').click(function(){
+			$('.button.link').addClass('active');
+
+			channel_id = prompt('Enter a name to link multiple teleprompters');
+
+			if(channel_id) {
+				channel = pusher.subscribe('private-'+channel_id);
+
+				//////////////////////////////////////
+				// CONTROLLER ⬇
+
+				// Send the initialization request to any server listening
+				channel.bind('pusher:subscription_succeeded', function() {
+				  channel.trigger('client-initreq', {type: 'initialize'});
+				});
+
+				// Wait for a server to send initialization data if any are listening
+				channel.bind('client-init', function(data) {
+					// Load in the remote content
+					$('#teleprompter').html(data.teleprompter_text);
+					$.cookie('teleprompter_text', data.teleprompter_text);
+
+					if(data.font_size) {
+						// Set this client's font size and speed values
+						fontSizeChangedLocally = true;
+						$('.font_size').slider('value', data.font_size);
+						fontSizeChangedLocally = false;
+					}
+					if(data.speed) {
+						speedChangedLocally = true;
+						$('.speed').slider('value', data.speed);
+						speedChangedLocally = false;
+					}
+
+					// Show the control button
+					$('.button.control').removeClass('hidden');
+				});
+
+				// CONTROLLER ⬆
+				//////////////////////////////////////
+				// SERVER/DISPLAY ⬇
+
+				// If a request is received to initialize another client, send this server's current state
+				channel.bind('client-initreq', function(data){
+					channel.trigger('client-init', {
+						teleprompter_text: $('#teleprompter').html(),
+						font_size: $('.font_size').slider('value'),
+						speed: $('.speed').slider('value')
+					});
+
+					// Show the control button, even though you wouldn't use it from the display device,
+					// but this way it doesn't matter in which order you initialize the devices
+					$('.button.control').removeClass('hidden');
+				});
+
+				// Handle remote commands
+				channel.bind('client-control', function(data){
+					if(data.action == 'play') {
+						start_teleprompter();
+					}
+					if(data.action == 'pause') {
+						stop_teleprompter();
+					}
+					if(data.action == 'scrollup') {
+						scrollUp();
+					}
+					if(data.action == 'scrolldown') {
+						scrollDown();
+					}
+					if(data.action == 'font_size') {
+						fontSizeChangedLocally = true;
+						$('.font_size').slider('value', data.font_size);
+						fontSizeChangedLocally = false;
+					}
+					if(data.action == 'speed') {
+						speedChangedLocally = true;
+						$('.speed').slider('value', data.speed);
+						speedChangedLocally = false;
+					}
+				});
+
+				// SERVER/DISPLAY ⬆
+				//////////////////////////////////////
+
+				// If the text is changed on either device, send it to the other
+				$('#teleprompter').keyup(function(){
+
+					channel.trigger('client-init', {
+						teleprompter_text: $('#teleprompter').html()
+					});
+
+				});
+
+			}
+
+		});
+
+
+		$('#control .close-controls').click(function(){
+			$('#control').addClass('hidden');
+		});
+
+		$('#control .control-play').click(function(){
+			var action;
+
+			if($(this).hasClass('icon-play')) {
+				$('#control .control-play').removeClass('icon-play').addClass('icon-pause');
+				action = 'play';
+			} else {
+				$('#control .control-play').removeClass('icon-pause').addClass('icon-play');
+				action = 'pause';
+			}
+
+			channel.trigger('client-control', {
+				action: action
+			});
+		});
+
+		$('#control .scroll-up').click(function(){
+			channel.trigger('client-control', {
+				action: 'scrollup'
+			});
+		});
+
+		$('#control .scroll-down').click(function(){
+			channel.trigger('client-control', {
+				action: 'scrolldown'
+			});
+		});
+
+		$('#control .font-size-control a').click(function(){
+			// The "change" event triggers sending the remote command
+			if($(this).hasClass('increase')) {
+				$('.font_size').slider('value', $('.font_size').slider('value') + 5);
+			} else {
+				$('.font_size').slider('value', $('.font_size').slider('value') - 5);
+			}
+		});
+
+		$('#control .speed-control a').click(function(){
+			// The "change" event triggers sending the remote command
+			if($(this).hasClass('increase')) {
+				$('.speed').slider('value', $('.speed').slider('value') + 2);
+			} else {
+				$('.speed').slider('value', $('.speed').slider('value') - 2);
+			}
+		});
+
+		$('.button.control').click(function(){
+			$('#control').removeClass('hidden');
+		});
+	});
+}
+
+
+var fontSizeChangedLocally = false;
+
+function controlFontSize() {
+	if(channel && !fontSizeChangedLocally) {
+		channel.trigger('client-control', {
+			action: 'font_size',
+			font_size: $('.font_size').slider('value')
+		});
+	}
+}
+
+var speedChangedLocally = false;
+
+function controlSpeed() {
+	if(channel && !speedChangedLocally) {
+		channel.trigger('client-control', {
+			action: 'speed',
+			speed: $('.speed').slider('value')
+		});
+	}
+}


### PR DESCRIPTION
This adds a remote control interface which can be loaded on another device. This will close #14.

Instead of writing a server-side component, I decided to go with Pusher.com to handle the realtime parts. That makes hosting this simpler, and also means writing less code.

Pusher API keys are defined in `js/pusher.php` which are used by both the PHP and JS side of things. Unfortunately Pusher requires server-side code in order to use client messaging, so I've implemented this in PHP as it seemed to be the easiest option to deploy. This does now require enabling PHP to host this project if you want to enable remote control.

To link two devices, click the little "link/paperclip" icon and enter some unique identifier on both devices. This becomes the name of the channel that the devices use to communicate. Once linked, changing the text on either device will push it to the other, along with changing the font size or speed settings.

You can pull up the control interface with the new icon that appears after linking a device. The remote control interface is designed to be used on a mobile phone, but does work fine on any device.

![Screenshot 2019-06-03 09 04 16](https://user-images.githubusercontent.com/113001/58816564-96c15f80-85de-11e9-8f91-abf768ea8465.png)

The remote control interface can start/pause the prompter, scroll up and down (useful when you need to go back and redo a line quickly), and can also change the font size and speed.

I've left this backwards compatible, so that if you don't define your Pusher API keys, you won't see any of the control interface. Also if you don't enable PHP on your hosting, it will be fine as well. The only thing you need to do to enable the remote control is define your pusher API keys in `js/pusher.php`.

Please let me know if you have any questions or feedback!