### PR TITLE
Fix annoying shift in text that can happen when playing/pausing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -80,9 +80,14 @@ article
 	overflow: auto;
 	background-color: #141414;
 }
-body.playing article
-{
-	overflow: hidden;
+body.playing article::-webkit-scrollbar {
+	background: #141414;
+}
+body.playing article::-webkit-scrollbar-thumb {
+	background: #141414;
+}
+body.playing article::-webkit-scrollbar-corner {
+	background: #141414;
 }
 article .teleprompter
 {


### PR DESCRIPTION
When you hit play or pause, the scrollbar appears or disappears. This can cause words to wrap or not wrap, depending on your content, which causes an annoying shift in the text.

This pull request hides the scrollbar (by styling it the same color as the background) instead of removing it, so the text no longer shifts. However, note that if the user customizes the background color, they may notice the black strip along the side (the restyled scrollbar), but it isn't very noticeable and IMO is preferable over text that shifts every time you pause or play.