### PR TITLE
Added support for keyCode commonly sent by presentation remotes

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -416,6 +416,11 @@
 			up = 38,
 			right = 39,
 			down = 40,
+			page_up = 33,
+			page_down = 34,
+			b_key = 66,
+			f5_key = 116,
+			period_key = 190,
 			speed = $('.speed').slider('value'),
 			font_size = $('.font_size').slider('value');
 
@@ -436,14 +441,14 @@
 			return false;
 		}
 		// Start Stop Scrolling
-		else if (evt.keyCode == space) {
+		else if (evt.keyCode == space || [b_key, f5_key, period_key].includes(evt.keyCode)) {
 			$('.button.play').trigger('click');
 			evt.preventDefault();
 			evt.stopPropagation();
 			return false;
 		}
 		// Decrease Speed with Left Arrow
-		else if (evt.keyCode == left) {
+		else if (evt.keyCode == left || evt.keyCode == page_up) {
 			$('.speed').slider('value', speed - 1);
 			evt.preventDefault();
 			evt.stopPropagation();
@@ -464,7 +469,7 @@
 			return false;
 		}
 		// Increase Speed with Right Arrow
-		else if (evt.keyCode == right) {
+		else if (evt.keyCode == right || evt.keyCode == page_down) {
 			$('.speed').slider('value', speed + 1);
 			evt.preventDefault();
 			evt.stopPropagation();


### PR DESCRIPTION
[Presentation remotes](https://bestreviews.com/best-presentation-remotes) are handy little devices that connect to your computer like a wireless keyboard and send button keypresses (typically to run a slideshow).

I've had a cheap little one for years (a Kensington) and I much prefer it to using my phone as a remote control, since the buttons are tactile and I don't need to look at it or wonder which button I'm pressing.

This pull request adds support for keypress events typically used by these remotes and maps them to functionality in the teleprompter:

* left/right buttons on remote -> page up/down keypress events -> speed up / slow down
* blank screen button, play/pause button -> "b" or "." key events or F5 -> play or pause